### PR TITLE
Add support for compact chat components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,26 @@
-# Contributing to AresRPG
-
 If you want to contribute come on [Discord](https://discord.gg/gaqrFT5) to chat with us beforehand
 
-## Workflow
+- [Workflow](#workflow)
+- [Code Style](#code-style)
+- [Architecture](#architecture)
+  - [State Management Pattern](#state-management-pattern)
+    - [State](#state)
+    - [Actions](#actions)
+    - [View](#view)
+  - [World](#world)
+  - [Chat components](#chat-components)
+  - [Distributed Server](#distributed-server)
+    - [Distributed Network Connections](#distributed-network-connections)
+    - [Seamless World Game Server](#seamless-world-game-server)
+    - [Responsibility-Oriented Game Server](#responsibility-oriented-game-server)
+
+# Workflow
 
 We use the [GitHub Flow](https://guides.github.com/introduction/flow/) to handle contributions
 
 Branch are usually merged with a fast-forward merge (sometimes with a rebase beforehand if no conflict happens)
 
-## Code Style
+# Code Style
 
 This codebase try to follow the [Declarative Programming](https://en.wikipedia.org/wiki/Declarative_programming) Paradigm,
 if you don't know this paradigm you can still contribute. Try to learn it while developing your contribution it's not required
@@ -113,6 +125,23 @@ listen to it on all the others
 You can add data to the world using a function called a `register` function.
 
 A register function take the world as argument and return a new world
+
+## Chat components
+
+Minecraft chat components are [quite verbose](https://wiki.vg/Chat#Colors), we provide a more handy way of writing them
+
+```js
+import compose from './chat_component'
+
+const component = [
+  compose('hello').green.bold,
+  compose('world').yellow.raw({
+    extra: [compose('!').underline.bold],
+    hoverEvent: ...
+  })
+]
+client.write('chat', JSON.stringify(component))
+```
 
 ## Distributed Server
 

--- a/src/chat_component.js
+++ b/src/chat_component.js
@@ -52,7 +52,7 @@ export default function (text) {
             return composable_component
           }
         throw new Error(
-          `Property ${property} is not supported in chat components`
+          `Property ${property?.toString()} is not supported in chat components`
         )
       },
     }

--- a/src/chat_component.js
+++ b/src/chat_component.js
@@ -1,0 +1,61 @@
+const Colors = {
+  black: { color: 'black' },
+  dark_blue: { color: 'dark_blue' },
+  dark_green: { color: 'dark_green' },
+  dark_aqua: { color: 'dark_aqua' },
+  dark_red: { color: 'dark_red' },
+  dark_purple: { color: 'dark_purple' },
+  gold: { color: 'gold' },
+  gray: { color: 'gray' },
+  dark_gray: { color: 'dark_gray' },
+  blue: { color: 'blue' },
+  green: { color: 'green' },
+  aqua: { color: 'aqua' },
+  red: { color: 'red' },
+  light_purple: { color: 'light_purple' },
+  yellow: { yello: 'yellow' },
+  white: { white: 'white' },
+}
+
+const Styles = {
+  obfuscated: { obfuscated: true },
+  bold: { bold: true },
+  strikethrough: { strikethrough: true },
+  underline: { underline: true },
+  italic: { italic: true },
+  reset: { reset: true },
+}
+
+const Properties = {
+  ...Colors,
+  ...Styles,
+}
+
+const Functions = {
+  raw: options => options,
+}
+
+export default function (text) {
+  const composable_component = new Proxy(
+    { text },
+    {
+      get(target, property, receiver) {
+        const component_property = Properties[property]
+        const component_extra = Functions[property]
+        if (component_property) {
+          Object.assign(target, component_property)
+          return composable_component
+        }
+        if (component_extra)
+          return (...parameters) => {
+            Object.assign(target, component_extra(...parameters))
+            return composable_component
+          }
+        throw new Error(
+          `Property ${property} is not supported in chat components`
+        )
+      },
+    }
+  )
+  return composable_component
+}


### PR DESCRIPTION
We can provide more options like `.hover()` etc, but it will be enough for a base

```js
import compose from './chat_component'
const component = [
  compose('hello').green.bold,
  compose('world').yellow.raw({
    extra: [compose('!').underline.bold],
    hoverEvent: ...
  })
]
client.write('chat', JSON.stringify(component))
```